### PR TITLE
Create casino lobby with blackjack and roulette games

### DIFF
--- a/Delete this file
+++ b/Delete this file
@@ -1,1 +1,0 @@
-placeholder

--- a/index.html
+++ b/index.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Luxe Casino Lounge</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@500;700&family=Poppins:wght@300;400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="table-glow"></div>
+    <main class="app-shell">
+      <header class="app-header">
+        <div class="brand">
+          <span class="brand-icon">♔</span>
+          <div>
+            <h1>Luxe Casino Lounge</h1>
+            <p>Step up to the tables and try your luck</p>
+          </div>
+        </div>
+        <button class="lobby-btn" data-target="start">Return to Lobby</button>
+      </header>
+
+      <section id="start-screen" class="screen active">
+        <div class="intro-card">
+          <h2>Choose Your Game</h2>
+          <p>
+            Whether you are here for strategic play or a spin of fate, the Luxe
+            Casino Lounge has a seat reserved just for you.
+          </p>
+          <div class="game-selector">
+            <button class="action-btn" data-game="blackjack">
+              <span>Play Blackjack</span>
+              <small>Beat the dealer &amp; hit 21</small>
+            </button>
+            <button class="action-btn" data-game="roulette">
+              <span>Spin Roulette</span>
+              <small>Pick your bet &amp; watch the wheel</small>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section id="blackjack-screen" class="screen">
+        <div class="game-header">
+          <h2>Blackjack Table</h2>
+          <p>Draw cards, chase 21, and stay one step ahead of the dealer.</p>
+        </div>
+        <div class="blackjack-table">
+          <div class="hand-column">
+            <h3>Dealer</h3>
+            <div class="card-row" id="dealer-hand"></div>
+            <p class="hand-value" id="dealer-score">Score: 0</p>
+          </div>
+          <div class="hand-column">
+            <h3>Player</h3>
+            <div class="card-row" id="player-hand"></div>
+            <p class="hand-value" id="player-score">Score: 0</p>
+          </div>
+        </div>
+        <div class="blackjack-controls">
+          <button id="blackjack-deal" class="accent">Deal New Round</button>
+          <div>
+            <button id="blackjack-hit">Hit</button>
+            <button id="blackjack-stand">Stand</button>
+          </div>
+        </div>
+        <p class="status-banner" id="blackjack-message"></p>
+      </section>
+
+      <section id="roulette-screen" class="screen">
+        <div class="game-header">
+          <h2>Roulette Wheel</h2>
+          <p>Select your bet, spin the wheel, and watch where the ball lands.</p>
+        </div>
+        <div class="roulette-layout">
+          <div class="wheel" aria-live="polite">
+            <div class="wheel-center">
+              <span id="roulette-number">--</span>
+              <small id="roulette-color">Ready</small>
+            </div>
+          </div>
+          <div class="betting-panel">
+            <div class="balance-display">
+              <h3>Chip Tray</h3>
+              <p>Balance: <span id="roulette-balance">500</span> credits</p>
+            </div>
+            <label class="input-label" for="bet-amount">Bet Amount</label>
+            <input
+              type="number"
+              id="bet-amount"
+              min="1"
+              value="25"
+              step="1"
+            />
+            <div class="bet-options" role="group" aria-label="Bet Types">
+              <button class="bet-option" data-bet="red">Red</button>
+              <button class="bet-option" data-bet="black">Black</button>
+              <button class="bet-option" data-bet="green">Green (0)</button>
+              <button class="bet-option" data-bet="number">Straight Up</button>
+            </div>
+            <label class="input-label" for="bet-number">Number (0-36)</label>
+            <input
+              type="number"
+              id="bet-number"
+              min="0"
+              max="36"
+              placeholder="Pick a number"
+            />
+            <button id="spin-wheel" class="accent">Spin the Wheel</button>
+            <p class="status-banner" id="roulette-message"></p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <script src="scripts.js"></script>
+  </body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,411 @@
+const screens = document.querySelectorAll('.screen');
+const lobbyButton = document.querySelector('.lobby-btn');
+const gameButtons = document.querySelectorAll('[data-game]');
+
+function activateScreen(targetId) {
+  screens.forEach((screen) => {
+    screen.classList.toggle('active', screen.id === targetId);
+  });
+
+  if (targetId === 'start-screen') {
+    lobbyButton.classList.add('hidden');
+  } else {
+    lobbyButton.classList.remove('hidden');
+  }
+}
+
+gameButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const game = btn.dataset.game;
+    activateScreen(`${game}-screen`);
+
+    if (game === 'blackjack') {
+      blackjack.resetRound();
+    }
+  });
+});
+
+lobbyButton.addEventListener('click', () => {
+  activateScreen('start-screen');
+});
+
+activateScreen('start-screen');
+
+// -----------------------------
+// Blackjack Logic
+// -----------------------------
+const blackjack = (() => {
+  const suits = ['♠', '♥', '♦', '♣'];
+  const ranks = [
+    { rank: 'A', value: 11 },
+    { rank: '2', value: 2 },
+    { rank: '3', value: 3 },
+    { rank: '4', value: 4 },
+    { rank: '5', value: 5 },
+    { rank: '6', value: 6 },
+    { rank: '7', value: 7 },
+    { rank: '8', value: 8 },
+    { rank: '9', value: 9 },
+    { rank: '10', value: 10 },
+    { rank: 'J', value: 10 },
+    { rank: 'Q', value: 10 },
+    { rank: 'K', value: 10 },
+  ];
+
+  const dealerHandEl = document.getElementById('dealer-hand');
+  const playerHandEl = document.getElementById('player-hand');
+  const dealerScoreEl = document.getElementById('dealer-score');
+  const playerScoreEl = document.getElementById('player-score');
+  const messageEl = document.getElementById('blackjack-message');
+  const dealBtn = document.getElementById('blackjack-deal');
+  const hitBtn = document.getElementById('blackjack-hit');
+  const standBtn = document.getElementById('blackjack-stand');
+
+  let deck = [];
+  let dealerHand = [];
+  let playerHand = [];
+  let roundActive = false;
+  let roundComplete = false;
+
+  function buildDeck() {
+    const freshDeck = [];
+
+    suits.forEach((suit) => {
+      ranks.forEach((rank) => {
+        freshDeck.push({ suit, rank: rank.rank, value: rank.value });
+      });
+    });
+
+    for (let i = freshDeck.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [freshDeck[i], freshDeck[j]] = [freshDeck[j], freshDeck[i]];
+    }
+
+    return freshDeck;
+  }
+
+  function drawCard() {
+    if (!deck.length) {
+      deck = buildDeck();
+    }
+
+    return deck.pop();
+  }
+
+  function calculateScore(hand) {
+    let total = 0;
+    let aces = 0;
+
+    hand.forEach((card) => {
+      total += card.value;
+      if (card.rank === 'A') {
+        aces += 1;
+      }
+    });
+
+    while (total > 21 && aces > 0) {
+      total -= 10;
+      aces -= 1;
+    }
+
+    return total;
+  }
+
+  function renderHand(hand, container, hideHoleCard = false) {
+    container.innerHTML = '';
+    hand.forEach((card, index) => {
+      const cardDiv = document.createElement('div');
+      const shouldHide = hideHoleCard && index === 1;
+
+      cardDiv.classList.add('card');
+
+      if (shouldHide) {
+        cardDiv.classList.add('back');
+      } else {
+        if (card.suit === '♥' || card.suit === '♦') {
+          cardDiv.classList.add('red');
+        }
+
+        const valueSpan = document.createElement('span');
+        valueSpan.className = 'value';
+        valueSpan.textContent = card.rank;
+
+        const suitSpan = document.createElement('span');
+        suitSpan.className = 'suit';
+        suitSpan.textContent = card.suit;
+
+        cardDiv.appendChild(valueSpan);
+        cardDiv.appendChild(suitSpan);
+      }
+
+      container.appendChild(cardDiv);
+    });
+  }
+
+  function setMessage(message, status) {
+    messageEl.textContent = message;
+    messageEl.classList.remove('win', 'lose', 'push');
+    if (status) {
+      messageEl.classList.add(status);
+    }
+  }
+
+  function updateUI(revealDealer = false) {
+    renderHand(playerHand, playerHandEl);
+    renderHand(dealerHand, dealerHandEl, !revealDealer && dealerHand.length > 1);
+
+    const playerScore = calculateScore(playerHand);
+    const dealerScore = calculateScore(dealerHand);
+
+    playerScoreEl.textContent = `Score: ${playerScore}`;
+
+    if (revealDealer || !roundActive || dealerHand.length <= 1) {
+      dealerScoreEl.textContent = `Score: ${dealerScore}`;
+    } else {
+      const visibleScore = calculateScore([dealerHand[0]]);
+      dealerScoreEl.textContent = `Score: ${visibleScore} + ?`;
+    }
+  }
+
+  function endRound(message, status) {
+    roundComplete = true;
+    roundActive = false;
+    updateUI(true);
+    setMessage(message, status);
+  }
+
+  function dealerTurn() {
+    while (calculateScore(dealerHand) < 17) {
+      dealerHand.push(drawCard());
+    }
+  }
+
+  function compareHands() {
+    const playerScore = calculateScore(playerHand);
+    const dealerScore = calculateScore(dealerHand);
+
+    if (dealerScore > 21) {
+      endRound('Dealer busts! You win the round.', 'win');
+    } else if (playerScore > dealerScore) {
+      endRound('You beat the dealer! Congratulations.', 'win');
+    } else if (playerScore < dealerScore) {
+      endRound('Dealer stands taller this time. You lose.', 'lose');
+    } else {
+      endRound('Push! It\'s a tie.', 'push');
+    }
+  }
+
+  function dealInitialCards() {
+    playerHand = [drawCard(), drawCard()];
+    dealerHand = [drawCard(), drawCard()];
+    updateUI(false);
+
+    const playerScore = calculateScore(playerHand);
+    const dealerScore = calculateScore(dealerHand);
+
+    if (playerScore === 21 && dealerScore === 21) {
+      endRound('Double blackjack! The round is a push.', 'push');
+    } else if (playerScore === 21) {
+      endRound('Blackjack! A natural 21 wins the round.', 'win');
+    } else if (dealerScore === 21) {
+      endRound('Dealer shows blackjack. Better luck next time.', 'lose');
+    } else {
+      setMessage('Make your move — hit or stand?', '');
+    }
+  }
+
+  function onDeal() {
+    roundActive = true;
+    roundComplete = false;
+    deck = buildDeck();
+    setMessage('Good luck! Dealing a fresh round.', '');
+    dealInitialCards();
+  }
+
+  function onHit() {
+    if (!roundActive || roundComplete) return;
+
+    playerHand.push(drawCard());
+    updateUI(false);
+
+    const playerScore = calculateScore(playerHand);
+
+    if (playerScore > 21) {
+      endRound('You bust! Dealer takes the round.', 'lose');
+    }
+  }
+
+  function onStand() {
+    if (!roundActive || roundComplete) return;
+
+    dealerTurn();
+    compareHands();
+  }
+
+  dealBtn.addEventListener('click', onDeal);
+  hitBtn.addEventListener('click', onHit);
+  standBtn.addEventListener('click', onStand);
+
+  function resetRound() {
+    roundActive = false;
+    roundComplete = false;
+    deck = buildDeck();
+    dealerHand = [];
+    playerHand = [];
+    updateUI(false);
+    setMessage('Tap "Deal New Round" to begin.', '');
+  }
+
+  resetRound();
+
+  return {
+    resetRound,
+  };
+})();
+
+// -----------------------------
+// Roulette Logic
+// -----------------------------
+const roulette = (() => {
+  const redNumbers = new Set([
+    1, 3, 5, 7, 9, 12, 14, 16, 18, 19, 21, 23, 25, 27, 30, 32, 34, 36,
+  ]);
+
+  const balanceEl = document.getElementById('roulette-balance');
+  const betAmountEl = document.getElementById('bet-amount');
+  const betNumberEl = document.getElementById('bet-number');
+  const messageEl = document.getElementById('roulette-message');
+  const spinButton = document.getElementById('spin-wheel');
+  const betButtons = document.querySelectorAll('.bet-option');
+  const wheelNumberEl = document.getElementById('roulette-number');
+  const wheelColorEl = document.getElementById('roulette-color');
+
+  let selectedBet = null;
+  let balance = 500;
+
+  function setMessage(message, status) {
+    messageEl.textContent = message;
+    messageEl.classList.remove('win', 'lose', 'push');
+    if (status) {
+      messageEl.classList.add(status);
+    }
+  }
+
+  function updateBalance() {
+    balanceEl.textContent = balance;
+  }
+
+  function selectBet(type) {
+    selectedBet = type;
+    betButtons.forEach((btn) => {
+      btn.classList.toggle('active', btn.dataset.bet === type);
+    });
+
+    if (type === 'number') {
+      betNumberEl.focus();
+    }
+  }
+
+  betButtons.forEach((btn) => {
+    btn.addEventListener('click', () => selectBet(btn.dataset.bet));
+  });
+
+  function getColor(number) {
+    if (number === 0) return 'green';
+    return redNumbers.has(number) ? 'red' : 'black';
+  }
+
+  function formatColorLabel(color) {
+    if (color === 'red') return 'Red';
+    if (color === 'black') return 'Black';
+    return 'Green';
+  }
+
+  function resolveSpin() {
+    if (!selectedBet) {
+      setMessage('Choose a bet type to get started.', '');
+      return;
+    }
+
+    const betAmount = Number.parseInt(betAmountEl.value, 10);
+
+    if (!Number.isFinite(betAmount) || betAmount <= 0) {
+      setMessage('Enter a valid bet amount to play.', '');
+      return;
+    }
+
+    if (betAmount > balance) {
+      setMessage('Not enough credits for that wager.', 'lose');
+      return;
+    }
+
+    let straightNumber = Number.parseInt(betNumberEl.value, 10);
+
+    if (selectedBet === 'number') {
+      if (!Number.isInteger(straightNumber) || straightNumber < 0 || straightNumber > 36) {
+        setMessage('Choose a valid roulette number between 0 and 36.', '');
+        return;
+      }
+    } else {
+      straightNumber = null;
+    }
+
+    balance -= betAmount;
+    updateBalance();
+
+    const resultNumber = Math.floor(Math.random() * 37);
+    const resultColor = getColor(resultNumber);
+
+    let winnings = 0;
+    let outcomeMessage = '';
+    let status = 'lose';
+
+    if (selectedBet === 'red' || selectedBet === 'black' || selectedBet === 'green') {
+      if (selectedBet === resultColor) {
+        const multiplier = selectedBet === 'green' ? 35 : 1;
+        winnings = betAmount * multiplier;
+        status = 'win';
+        outcomeMessage = `You called ${formatColorLabel(resultColor)} and won ${
+          winnings + betAmount
+        } credits!`;
+      } else {
+        outcomeMessage = `The wheel landed on ${resultNumber} ${formatColorLabel(
+          resultColor
+        )}. Better luck next spin.`;
+      }
+    } else if (selectedBet === 'number') {
+      if (resultNumber === straightNumber) {
+        winnings = betAmount * 35;
+        status = 'win';
+        outcomeMessage = `Straight up hit! Number ${resultNumber} pays ${
+          winnings + betAmount
+        } credits.`;
+      } else {
+        outcomeMessage = `No match this time. The wheel shows ${resultNumber} ${formatColorLabel(
+          resultColor
+        )}.`;
+      }
+    }
+
+    if (winnings > 0) {
+      balance += betAmount + winnings;
+    }
+
+    updateBalance();
+
+    wheelNumberEl.textContent = resultNumber;
+    wheelColorEl.textContent = formatColorLabel(resultColor);
+    wheelColorEl.className = resultColor;
+
+    setMessage(outcomeMessage, status);
+  }
+
+  spinButton.addEventListener('click', resolveSpin);
+
+  selectBet('red');
+  updateBalance();
+
+  return {
+    selectBet,
+  };
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,527 @@
+:root {
+  --bg: radial-gradient(circle at top, #1b1f3b 0%, #0b0e20 45%, #03050f 100%);
+  --glass: rgba(255, 255, 255, 0.08);
+  --accent: #f8c75f;
+  --accent-strong: #f2a93b;
+  --text-primary: #f5f6ff;
+  --text-secondary: rgba(245, 246, 255, 0.7);
+  --card-bg: rgba(14, 19, 41, 0.85);
+  --shadow: 0 30px 60px rgba(0, 0, 0, 0.45);
+  --border-light: rgba(255, 255, 255, 0.2);
+  --win: #54d47b;
+  --lose: #ff6b6b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Poppins", sans-serif;
+  background: var(--bg);
+  color: var(--text-primary);
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1.5rem;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: url("https://images.unsplash.com/photo-1542144812-0694b3a7baf1?auto=format&fit=crop&w=1600&q=80")
+      center / cover no-repeat;
+  opacity: 0.18;
+  z-index: -2;
+}
+
+.table-glow {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at center, rgba(44, 160, 96, 0.35), transparent 60%),
+    radial-gradient(circle at bottom, rgba(0, 112, 168, 0.3), transparent 65%);
+  filter: blur(35px);
+  opacity: 0.9;
+  z-index: -1;
+}
+
+.app-shell {
+  width: min(1100px, 100%);
+  background: linear-gradient(160deg, rgba(17, 23, 42, 0.88), rgba(9, 12, 25, 0.88));
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.75rem 2.25rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: rgba(10, 15, 30, 0.75);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-icon {
+  font-size: 2.8rem;
+  line-height: 1;
+  color: var(--accent);
+}
+
+.brand h1 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 3vw, 2.4rem);
+  margin: 0;
+}
+
+.brand p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-weight: 300;
+}
+
+.lobby-btn {
+  border: 1px solid var(--border-light);
+  background: transparent;
+  color: var(--text-primary);
+  font-weight: 500;
+  border-radius: 999px;
+  padding: 0.65rem 1.6rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.lobby-btn.hidden {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lobby-btn:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.screen {
+  display: none;
+  padding: 2.5rem clamp(1.5rem, 4vw, 3rem) 3rem;
+  min-height: 580px;
+}
+
+.screen.active {
+  display: block;
+  animation: fadeIn 0.5s ease;
+}
+
+.game-header {
+  text-align: center;
+  max-width: 620px;
+  margin: 0 auto 2.5rem;
+}
+
+.game-header h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 0.5rem;
+}
+
+.game-header p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.intro-card {
+  background: var(--card-bg);
+  padding: clamp(2rem, 6vw, 3.5rem);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  text-align: center;
+  max-width: 640px;
+  margin: 0 auto;
+}
+
+.intro-card h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.2rem, 4vw, 3rem);
+  margin-bottom: 0.75rem;
+}
+
+.intro-card p {
+  color: var(--text-secondary);
+  margin-bottom: 2.25rem;
+}
+
+.game-selector {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.action-btn {
+  background: linear-gradient(135deg, rgba(248, 199, 95, 0.12), rgba(248, 199, 95, 0.08));
+  border: 1px solid rgba(248, 199, 95, 0.35);
+  color: var(--text-primary);
+  padding: 1.2rem 1.4rem;
+  border-radius: 18px;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.action-btn span {
+  display: block;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.action-btn small {
+  color: var(--text-secondary);
+  display: block;
+  margin-top: 0.4rem;
+}
+
+.action-btn:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 32px rgba(248, 199, 95, 0.16);
+}
+
+.blackjack-table {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+  background: rgba(15, 58, 36, 0.4);
+  border: 1px solid rgba(84, 212, 123, 0.25);
+  border-radius: 22px;
+  padding: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.blackjack-table::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 20px;
+  border: 1px solid rgba(84, 212, 123, 0.28);
+  pointer-events: none;
+}
+
+.hand-column h3 {
+  margin: 0 0 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.card-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  min-height: 130px;
+}
+
+.card {
+  width: 70px;
+  height: 100px;
+  border-radius: 12px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.9), rgba(246, 246, 246, 0.85));
+  box-shadow: 0 15px 25px rgba(0, 0, 0, 0.28);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 0.5rem;
+  color: #1b1f3b;
+  font-weight: 600;
+  position: relative;
+}
+
+.card.back {
+  background: linear-gradient(160deg, rgba(18, 25, 56, 0.9), rgba(5, 8, 20, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  justify-content: center;
+  align-items: center;
+}
+
+.card.back::after {
+  content: "♣";
+  font-size: 1.6rem;
+  color: rgba(248, 199, 95, 0.8);
+}
+
+.card.red {
+  color: #c62828;
+}
+
+.card span {
+  font-family: "Playfair Display", serif;
+}
+
+.card .value {
+  font-size: 1.45rem;
+}
+
+.card .suit {
+  font-size: 1.2rem;
+  align-self: flex-end;
+}
+
+.hand-value {
+  margin-top: 1rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.blackjack-controls {
+  margin-top: 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.blackjack-controls button {
+  padding: 0.8rem 1.8rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text-primary);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.blackjack-controls button:hover {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.blackjack-controls .accent,
+#spin-wheel.accent {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #1b1f3b;
+}
+
+.blackjack-controls .accent:hover,
+#spin-wheel.accent:hover {
+  background: linear-gradient(135deg, var(--accent-strong), #ef8f2f);
+}
+
+.status-banner {
+  text-align: center;
+  min-height: 1.5em;
+  margin-top: 1.5rem;
+  font-weight: 500;
+}
+
+.status-banner.win {
+  color: var(--win);
+}
+
+.status-banner.lose {
+  color: var(--lose);
+}
+
+.status-banner.push {
+  color: var(--accent);
+}
+
+.roulette-layout {
+  display: grid;
+  gap: clamp(2rem, 5vw, 4rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.wheel {
+  width: clamp(240px, 40vw, 320px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: conic-gradient(
+      #d13b43 0 15deg,
+      #0f1b33 15deg 25deg,
+      #d13b43 25deg 35deg,
+      #0f1b33 35deg 45deg,
+      #d13b43 45deg 55deg,
+      #0f1b33 55deg 65deg,
+      #d13b43 65deg 75deg,
+      #0f1b33 75deg 90deg,
+      #d13b43 90deg 105deg,
+      #0f1b33 105deg 120deg,
+      #d13b43 120deg 135deg,
+      #0f1b33 135deg 150deg,
+      #d13b43 150deg 165deg,
+      #0f1b33 165deg 180deg,
+      #d13b43 180deg 195deg,
+      #0f1b33 195deg 210deg,
+      #d13b43 210deg 225deg,
+      #0f1b33 225deg 240deg,
+      #d13b43 240deg 255deg,
+      #0f1b33 255deg 270deg,
+      #d13b43 270deg 285deg,
+      #0f1b33 285deg 300deg,
+      #d13b43 300deg 315deg,
+      #0f1b33 315deg 330deg,
+      #d13b43 330deg 345deg,
+      #0f1b33 345deg 360deg
+    ),
+    radial-gradient(circle at center, rgba(0, 0, 0, 0.75) 65%, transparent 66%);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+  display: grid;
+  place-items: center;
+  position: relative;
+}
+
+.wheel::after {
+  content: "";
+  position: absolute;
+  top: -14px;
+  width: 24px;
+  height: 24px;
+  background: var(--accent);
+  clip-path: polygon(50% 0, 0 100%, 100% 100%);
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.35));
+}
+
+.wheel-center {
+  width: 40%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at top, #fff6da, #f4b347);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: #1b1f3b;
+  font-weight: 700;
+  gap: 0.25rem;
+  box-shadow: inset 0 4px 8px rgba(255, 255, 255, 0.3), inset 0 -4px 8px rgba(0, 0, 0, 0.25);
+}
+
+.wheel-center span {
+  font-size: clamp(2rem, 5vw, 2.6rem);
+}
+
+.wheel-center small {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+#roulette-color.red {
+  color: #d13b43;
+}
+
+#roulette-color.black {
+  color: #0f1b33;
+}
+
+#roulette-color.green {
+  color: #2ec27e;
+}
+
+.betting-panel {
+  background: rgba(17, 23, 42, 0.72);
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.balance-display h3 {
+  margin: 0 0 0.25rem;
+}
+
+.balance-display p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.input-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+input[type="number"] {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  font-size: 1rem;
+}
+
+input[type="number"]:focus {
+  outline: 2px solid rgba(248, 199, 95, 0.55);
+}
+
+.bet-options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.bet-option {
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-primary);
+  padding: 0.9rem 1rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: background 0.25s ease, transform 0.25s ease;
+}
+
+.bet-option:hover {
+  background: rgba(255, 255, 255, 0.16);
+  transform: translateY(-2px);
+}
+
+.bet-option.active {
+  border-color: var(--accent);
+  box-shadow: 0 12px 20px rgba(248, 199, 95, 0.15);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 2rem 1rem;
+  }
+
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .lobby-btn {
+    align-self: stretch;
+  }
+
+  .blackjack-controls {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a luxurious lobby screen that routes players to blackjack or roulette
- implement an interactive blackjack table with card rendering, hit/stand logic, and round messaging
- build a roulette wheel experience with selectable bets, animated layout, and balance tracking

## Testing
- not run (static web project)


------
https://chatgpt.com/codex/tasks/task_e_68ccbbe289a48332bc58511b87037bf4