### PR TITLE
Enhance roulette experience with numbered wheel and betting grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,11 +90,14 @@
         </div>
 
         <div class="roulette-layout glass">
-          <div class="wheel-wrapper">
-            <div class="pointer"></div>
-            <div class="roulette-wheel" id="roulette-wheel">
-              <div class="wheel-center"></div>
+          <div class="wheel-column">
+            <div class="wheel-wrapper">
+              <div class="pointer"></div>
+              <div class="roulette-wheel" id="roulette-wheel">
+                <div class="wheel-center"></div>
+              </div>
             </div>
+            <div class="roulette-grid" id="roulette-grid"></div>
           </div>
 
           <div class="betting-panel">

--- a/style.css
+++ b/style.css
@@ -398,18 +398,25 @@ button:disabled {
 }
 
 /* Roulette */
+
 .roulette-layout {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) 1fr;
+  grid-template-columns: minmax(260px, 360px) 1fr;
   gap: 2.5rem;
+  align-items: flex-start;
+}
+
+.wheel-column {
+  display: flex;
+  flex-direction: column;
   align-items: center;
+  gap: 1.75rem;
 }
 
 .wheel-wrapper {
   position: relative;
-  width: 280px;
-  height: 280px;
-  margin: 0 auto;
+  width: 300px;
+  height: 300px;
 }
 
 .pointer {
@@ -430,15 +437,55 @@ button:disabled {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  background: conic-gradient(#16a085 0deg 9.73deg, rgba(22, 194, 208, 0) 9.73deg 9.8deg),
-    repeating-conic-gradient(#e74c3c 0deg 9.73deg, #2c3e50 9.73deg 19.46deg);
+  background: radial-gradient(
+      circle at 50% 45%,
+      rgba(255, 255, 255, 0.22),
+      rgba(255, 255, 255, 0) 62%
+    ),
+    repeating-conic-gradient(
+      rgba(255, 77, 103, 0.85) 0deg 9.73deg,
+      rgba(44, 62, 80, 0.9) 9.73deg 19.46deg
+    );
   box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.5), 0 15px 35px rgba(0, 0, 0, 0.55);
   border: 10px solid rgba(0, 0, 0, 0.45);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: transform 2.6s cubic-bezier(0.25, 0.1, 0.25, 1);
+  overflow: hidden;
+  transition: transform 3.2s cubic-bezier(0.18, 0.68, 0.35, 1);
   transform: rotate(var(--rotation, 0deg));
+}
+
+.wheel-numbers {
+  position: absolute;
+  inset: 18px;
+  border-radius: 50%;
+  pointer-events: none;
+}
+
+.wheel-number {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 2.3rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+  font-weight: 600;
+  text-align: center;
+  transform-origin: center;
+  text-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+}
+
+.wheel-number.red {
+  color: #ffb0bd;
+}
+
+.wheel-number.black {
+  color: #d6deff;
+}
+
+.wheel-number.green {
+  color: #c4fbd8;
 }
 
 .roulette-wheel::after {
@@ -458,6 +505,105 @@ button:disabled {
   background: linear-gradient(135deg, #0f172a, #1f2a44);
   z-index: 1;
   box-shadow: 0 6px 14px rgba(0, 0, 0, 0.4);
+}
+
+.roulette-grid {
+  display: grid;
+  grid-template-columns: minmax(52px, 68px) repeat(3, minmax(52px, 68px));
+  grid-auto-rows: 52px;
+  gap: 0.4rem;
+  justify-content: center;
+}
+
+.roulette-grid.disabled {
+  opacity: 0.65;
+}
+
+.grid-cell {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--text);
+  font-weight: 600;
+  background: rgba(15, 81, 50, 0.8);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  padding: 0;
+  outline: none;
+  appearance: none;
+}
+
+.grid-cell:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.25);
+}
+
+.grid-cell.red {
+  background: linear-gradient(135deg, rgba(255, 77, 103, 0.9), rgba(185, 27, 53, 0.9));
+}
+
+.grid-cell.black {
+  background: linear-gradient(135deg, rgba(36, 42, 62, 0.92), rgba(16, 21, 35, 0.92));
+}
+
+.grid-cell.zero {
+  background: linear-gradient(135deg, rgba(43, 102, 69, 0.95), rgba(25, 71, 47, 0.95));
+  grid-row: span 12;
+}
+
+.grid-cell .number-label {
+  font-size: 0.95rem;
+}
+
+.grid-cell .chip {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: linear-gradient(135deg, var(--accent), #fce2a2);
+  color: #2c1a00;
+  font-weight: 700;
+  font-size: 0.75rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.45);
+  display: none;
+}
+
+.grid-cell.has-chip .chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.grid-cell.has-chip .number-label {
+  opacity: 0.25;
+}
+
+.grid-cell.selected {
+  border-color: rgba(255, 255, 255, 0.45);
+  box-shadow: 0 10px 20px rgba(248, 212, 121, 0.35);
+}
+
+.grid-cell.hit {
+  animation: tableHit 1.6s ease;
+}
+
+@keyframes tableHit {
+  0% {
+    box-shadow: 0 0 0 0 rgba(248, 212, 121, 0.45);
+  }
+  60% {
+    box-shadow: 0 0 0 5px rgba(248, 212, 121, 0.25);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(248, 212, 121, 0);
+  }
 }
 
 .betting-panel {
@@ -511,6 +657,21 @@ button:disabled {
     text-align: center;
   }
 
+  .wheel-column {
+    gap: 1.25rem;
+  }
+
+  .wheel-wrapper {
+    width: 260px;
+    height: 260px;
+  }
+
+  .roulette-grid {
+    grid-template-columns: minmax(48px, 60px) repeat(3, minmax(48px, 60px));
+    grid-auto-rows: 48px;
+    margin: 0 auto;
+  }
+
   .betting-panel {
     justify-items: center;
   }
@@ -532,6 +693,16 @@ button:disabled {
   .card {
     width: 64px;
     height: 96px;
+  }
+
+  .wheel-wrapper {
+    width: 240px;
+    height: 240px;
+  }
+
+  .roulette-grid {
+    grid-template-columns: minmax(44px, 52px) repeat(3, minmax(44px, 52px));
+    grid-auto-rows: 44px;
   }
 
   .controls {


### PR DESCRIPTION
## Summary
- render roulette wheel segments and numbers in the authentic order and spin the wheel to land on the winning slot
- add an interactive roulette table grid for placing number bets with chip indicators tied to the bet amount
- refresh roulette styling and responsiveness for the new wheel and betting layout

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ccbfbdf9448332943c803a4d6908bf