### PR TITLE
Align roulette pointer and label angles with top reference

### DIFF
--- a/script.js
+++ b/script.js
@@ -435,7 +435,7 @@ document.addEventListener("DOMContentLoaded", () => {
       label.classList.add("wheel-number", color);
       label.dataset.number = number;
       label.textContent = number;
-      const centerAngle = -90 + index * segmentAngle;
+      const centerAngle = index * segmentAngle;
       label.style.setProperty("--angle", `${centerAngle}deg`);
       rouletteWheelNumbers.append(label);
       wheelNumberElements.set(number, label);
@@ -762,10 +762,10 @@ document.addEventListener("DOMContentLoaded", () => {
     const currentRotation = rouletteState.rotation;
     const currentNormalized = ((currentRotation % 360) + 360) % 360;
     const targetIndex = numberIndexMap.get(winningNumber) ?? 0;
-    const pointerAngle = 270;
-    const labelAngle =
-      ((-90 + targetIndex * segmentAngle) % 360 + 360) % 360;
-    let deltaRotation = pointerAngle - labelAngle - currentNormalized;
+    const pointerAngle = 0;
+    const pocketAngle =
+      ((targetIndex * segmentAngle) % 360 + 360) % 360;
+    let deltaRotation = pointerAngle - pocketAngle - currentNormalized;
     deltaRotation = ((deltaRotation % 360) + 360) % 360;
     if (deltaRotation < 1e-4) {
       deltaRotation += 360;


### PR DESCRIPTION
## Summary
- align the roulette wheel number labels with a top-based origin so the zero pocket sits at twelve o'clock
- recalculate the spin alignment to use matching pointer and pocket angles measured from the top of the wheel

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68ccece00a948332b04c74f6ce722cb3